### PR TITLE
Return correct HTTP authorization error codes

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -134,7 +134,6 @@ function validateSomePermissionCluster (logger) {
         const error = new Error(`Insufficient permissions! Permissions ${validators.join(', ')} are required`)
         logger.error(error)
         res.status(403).send(error)
-        next()
       }
     }
   }

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -114,7 +114,7 @@ function validateSomePermissionCluster (logger) {
             }
           }
 
-          // If some permission is validated, then the user matchs the validator
+          // If some permission is validated, then the user matches the validator
           if (match.length > 0) {
             req.permissions.validated.push({
               by: 'expression',
@@ -125,7 +125,7 @@ function validateSomePermissionCluster (logger) {
         }
       }
 
-      // If some validator were validated, pass test
+      // If some validator was validated, pass test
       if (req.permissions.validated.length > 0) {
         logger.debug('User passed permission test')
         if (next) { next() }
@@ -133,7 +133,8 @@ function validateSomePermissionCluster (logger) {
       } else {
         const error = new Error(`Insufficient permissions! Permissions ${validators.join(', ')} are required`)
         logger.error(error)
-        res.status(401).send(error)
+        res.status(403).send(error)
+        next()
       }
     }
   }

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -78,7 +78,7 @@ class QuotiAuth {
         let code = 500
         if (err?.message === 'Missing authentication' || err?.response?.data?.includes("Decoding Firebase ID")) {
           code = 401
-        } else if ('Insufficient permissions or user is null') {
+        } else if (err?.message === 'Insufficient permissions or user is null') {
           code = 403
         }
         res.status(code).send(err?.response?.data || err);

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -1,6 +1,5 @@
 
 const axios = require('axios')
-const { response } = require('express')
 const Permissions = require('./permissions')
 class QuotiAuth {
   constructor (orgSlug, apiKey, getUserData, logger) {


### PR DESCRIPTION
If a request has no authentication information, error code 401 shoule be returned. However, if the user is authenticated but doesn't have permission to perform an action, error code 403 should be returned.