### PR TITLE
[TASK-1030] feat: allow quotiAuth.middleware receive an object as argument

### DIFF
--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -134,8 +134,8 @@ class QuotiAuth {
         }
 
         if (permissionsArray) {
-          const flattendPermissionArray = flattenDeep(permissionsArray)
-          includePermissions = flattendPermissionArray?.length !== 0 ? flattendPermissionArray : false
+          const flattenedPermissionArray = flattenDeep(permissionsArray)
+          includePermissions = flattenedPermissionArray?.length !== 0 ? flattenedPermissionArray : false
         }
 
         const result = await this.getUserData({

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -150,10 +150,11 @@ class QuotiAuth {
         })
 
         req.user = result
-        const permissionsToValidate =
-          permissions?.permissionsToValidate || permissions
+        const permissionsToValidate = Array.isArray(permissions)
+          ? permissions
+          : permissions?.permissionsToValidate
 
-        if (permissionsToValidate && permissionsToValidate.length) {
+        if (permissionsToValidate && permissionsToValidate?.length) {
           const permissionsResult = this.validateSomePermissionCluster(
             permissionsToValidate
           )(req, res)

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -134,7 +134,8 @@ class QuotiAuth {
         }
 
         if (permissionsArray) {
-          includePermissions = permissionsArray?.length !== 0 ? flattenDeep(permissionsArray) : false
+          const flattendPermissionArray = flattenDeep(permissionsArray)
+          includePermissions = flattendPermissionArray?.length !== 0 ? flattendPermissionArray : false
         }
 
         const result = await this.getUserData({

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -103,7 +103,7 @@ class QuotiAuth {
    * @param {import('./permissions').Validators} permissions
    * @returns {Middleware}
    */
-  middleware (permissionsParam = null) {
+  middleware (permissions = null) {
     return async (req, res, next) => {
       try {
         let token = req?.body?.token
@@ -119,14 +119,17 @@ class QuotiAuth {
         }
 
         let includePermissions = true
-        let permissionsArray = permissionsParam
+        let permissionsArray = permissions
 
         if (
-          permissionsParam &&
-          !Array.isArray(permissionsParam) &&
-          typeof permissionsParam === 'object'
+          permissions &&
+          !Array.isArray(permissions)
         ) {
-          const { permissionsToFetch, permissionsToValidate } = permissionsParam
+          if (typeof permissions !== 'object') {
+            throw new Error('Invalid permissions argument. Must be an object or an array of strings.')
+          }
+
+          const { permissionsToFetch, permissionsToValidate } = permissions
           permissionsArray = []
           permissionsArray = permissionsArray
             .concat(permissionsToFetch || [])
@@ -145,7 +148,7 @@ class QuotiAuth {
         })
 
         req.user = result
-        const permissionsToValidate = permissionsParam?.permissionsToValidate || permissionsParam
+        const permissionsToValidate = permissions?.permissionsToValidate || permissions
 
         if (permissionsToValidate && permissionsToValidate.length) {
           const permissionsResult = this.validateSomePermissionCluster(

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -121,12 +121,11 @@ class QuotiAuth {
         let includePermissions = true
         let permissionsArray = permissions
 
-        if (
-          permissions &&
-          !Array.isArray(permissions)
-        ) {
+        if (permissions && !Array.isArray(permissions)) {
           if (typeof permissions !== 'object') {
-            throw new Error('Invalid permissions argument. Must be an object or an array of strings.')
+            throw new Error(
+              'Invalid permissions argument. Must be an object or an array of strings.'
+            )
           }
 
           const { permissionsToFetch, permissionsToValidate } = permissions
@@ -138,7 +137,10 @@ class QuotiAuth {
 
         if (permissionsArray) {
           const flattenedPermissionArray = flattenDeep(permissionsArray)
-          includePermissions = flattenedPermissionArray?.length !== 0 ? flattenedPermissionArray : false
+          includePermissions =
+            flattenedPermissionArray?.length !== 0
+              ? flattenedPermissionArray
+              : false
         }
 
         const result = await this.getUserData({
@@ -148,7 +150,8 @@ class QuotiAuth {
         })
 
         req.user = result
-        const permissionsToValidate = permissions?.permissionsToValidate || permissions
+        const permissionsToValidate =
+          permissions?.permissionsToValidate || permissions
 
         if (permissionsToValidate && permissionsToValidate.length) {
           const permissionsResult = this.validateSomePermissionCluster(

--- a/src/quotiauth.js
+++ b/src/quotiauth.js
@@ -123,6 +123,18 @@ class QuotiAuth {
         if (permissions && Array.isArray(permissions)) {
           includePermissions =
             permissions.length !== 0 ? flattenDeep(permissions) : false
+        } else if (permissions && typeof permissions === 'object') {
+          const { permissionsToFetch, permissionsToValidate } = permissions
+          includePermissions = []
+          if (permissionsToFetch) {
+            includePermissions = includePermissions.concat(flattenDeep(permissionsToFetch))
+          }
+          if (permissionsToValidate) {
+            includePermissions = includePermissions.concat(flattenDeep(permissionsToValidate))
+          }
+          if (includePermissions.length === 0) {
+            includePermissions = false
+          }
         }
 
         const result = await this.getUserData({
@@ -135,6 +147,13 @@ class QuotiAuth {
         if (permissions && permissions.length) {
           const permissionsResult = this.validateSomePermissionCluster(
             permissions
+          )(req, res)
+          if (!permissionsResult) {
+            throw new Error('Insufficient permissions or user is null')
+          }
+        } else if (permissions && permissions.permissionsToValidate && permissions.permissionsToValidate.length) {
+          const permissionsResult = this.validateSomePermissionCluster(
+            permissions.permissionsToValidate
           )(req, res)
           if (!permissionsResult) {
             throw new Error('Insufficient permissions or user is null')


### PR DESCRIPTION
## Description
At the moment, quotiAuth.middleware only can receive an array of arrays as param. It now also supports receiving an object (with permissionsToFetch and permissionsToValidate)
### ℹ️ Goals:
  allow quotiAuth.middleware receive an object or an array of arrays as param

## Type of change

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🔥 Hot Fix
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] ⏩ Revert
- [ ] 📦 Chore (Release)
- [ ] 🔁 CI
- [ ] 📝 Documentation Update


## **Required** About this PR?

- [x]  Non-breaking change
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚠️ This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?
using the /tickets endpoint of csm-api:
- [x] receiving an array of array, the bahavior remained the same. (empty or non empty)
- [x] receiving an object with permissionsToValidate as an empty array of arrays, it returned the error that the user doesn't have permission to list tickets
- [x] receiving an object with permissionsToFetch only, it returned the error that the user doesn't have permission to list tickets
- [x] receiving an object with bot permissionToFetch and permissionToValidate, added both to includePermissions and calls the function to validate permissions with permissionsToValidate