### PR TITLE
[TASK-1352] Bugfix/recognize error in permissions result

### DIFF
--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,0 +1,17 @@
+/**
+ * Checks if a given HTTP status code indicates an error.
+ *
+ * This function determines if the provided status code falls within the
+ * range typically associated with client (4xx) or server (5xx) error responses,
+ * thus identifying whether the status code represents an error.
+ *
+ * @param {number} statusCode - The HTTP status code to be evaluated.
+ * @returns {boolean} Returns `true` if the status code is an error code (between 400 and 599 inclusive); otherwise, returns `false`.
+ */
+export function isErrorStatusCode (statusCode) {
+  if (typeof statusCode !== 'number') {
+    return false
+  }
+
+  return statusCode >= 400 && statusCode < 600
+}


### PR DESCRIPTION
## Description

- When `quotiAuth.middleware` called `this.validateSomePermissionCluster` and it returned a `permissionsResult` that had an error in it, it didn't throw, because it only checked whether `permissionsResult` was falsy.
          - so the server continued to process the request even though the user didn't have the permission required.

### ℹ️ Goals:
- Throw when `permissionsResult` carries an error in it.
      - that can be identified in its statusCode.
### ❗Problems:
  What problems did you found?
  
## Type of change

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hot Fix
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] ⏩ Revert
- [ ] 📦 Chore (Release)
- [ ] 🔁 CI
- [ ] 📝 Documentation Update


## **Required** About this PR?

- [ ]  Non-breaking change
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚠️ This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

- [ ] Call an endpoint that uses the middleware `quotiAuth.middleware` and pass a permission your user doesn't have to the permissions param of the middleware and check that it throws.